### PR TITLE
%lang_package: avoid requirement on shared library providing extra symbols

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -263,7 +263,7 @@
 %package %{-n:-n %{-n*}-}lang \
 Summary: Translations for package %{name} \
 Group: System/Localization \
-Requires: %{-n:%{-n*}}%{!-n:%{name}} = %{version} \
+Requires: %{-n:%{-n*} = %{version}} %{!-n:%{!-r:%{name} = %{version}}} \
 %{-r:Requires: %{-r*}} \
 Provides: %{-n:%{-n*}}%{!-n:%{name}}-lang-all = %{version} \
 Supplements: %{-n:%{-n*}}%{!-n:%{name}} \


### PR DESCRIPTION
If only a shared library and its language package exist, then there are
two ways:

`%lang_package -n libconfuse2`: Creates an unwanted
"libconfuse2-lang", but at least it depends on "libconfuse2".

`%lang_package -r libconfuse2`: Creates a "libconfuse-lang", but adds
an unwanted dependency on "libconfuse".

Rewrite the %lang_package macro such that the presence of any -r
argument inhibits implicit Requires.

---

There is just one package in openSUSE that even uses `-r`, so there is no extra work really.