### PR TITLE
Fix superfluous TOC. dependency on ppc64 (bsc#1113100), Add kernel module provides kmod(modulename) (FATE#326579). Add automatic kernel module requires for module-load.d files

### DIFF
--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  5 16:05:14 UTC 2019 - Michal Suchanek <msuchanek@suse.de>
+
+- Add automatic kernel module requires for module-load.d files
+  (FATE#326579).
+
+-------------------------------------------------------------------
 Wed Jan 30 13:57:55 CET 2019 - mls@suse.de
 
 - Added macros.d/macros.initrd

--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Apr 25 16:15:13 UTC 2019 - Michal Suchanek <msuchanek@suse.de>
+
+- Provide/require modules with .ko suffix (jsc#SLE-3853)
+
+-------------------------------------------------------------------
 Wed Apr 10 09:59:33 CEST 2019 - kukuk@suse.de
 
 - Don't use bash syntax in %install_info macro [bsc#1131957]

--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -4,6 +4,11 @@ Wed Jan 30 13:57:55 CET 2019 - mls@suse.de
 - Added macros.d/macros.initrd
 
 -------------------------------------------------------------------
+Wed Oct 24 16:10:40 CEST 2018 - msuchanek@suse.de
+
+- Fix superfluous TOC. dependency (bsc#1113100)
+
+-------------------------------------------------------------------
 Fri Oct 12 14:17:05 UTC 2018 - Jan Engelhardt <jengelh@inai.de>
 
 - Update to new snapshot 0.g8

--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -4,6 +4,11 @@ Wed Jan 30 13:57:55 CET 2019 - mls@suse.de
 - Added macros.d/macros.initrd
 
 -------------------------------------------------------------------
+Tue Dec 18 20:10:04 UTC 2018 - Michal Suchanek <msuchanek@suse.de>
+
+- Add kmod(module) provides to kernel and KMPs (FATE#326579).
+
+-------------------------------------------------------------------
 Wed Oct 24 16:10:40 CEST 2018 - msuchanek@suse.de
 
 - Fix superfluous TOC. dependency (bsc#1113100)

--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -27,12 +27,25 @@ while read f; do
     */boot/vmlinu[xz]-*)
         flavor=${f##*/vmlinu[xz]-}
         flavor=${flavor%.gz}
-        echo "kernel-uname-r = $flavor"
         version=${flavor}
+        inst_prefix="$(dirname $f)"
+        inst_prefix="$(dirname $inst_prefix)"
+        echo "kernel-uname-r = $version"
+        builtin="$inst_prefix/lib/modules/$version/modules.builtin"
+        if [ -e "$builtin" ] ; then
+                while read mod ; do
+                        echo "kmod($(basename "$mod" .ko | tr '-' '_'))"
+                done < "$builtin"
+        else
+                echo "Builtin modules for $f not available in $builtin" >&2
+        fi
         flavor=${flavor##*-}
         ;;
-    */lib/modules/*/*.ko | */lib/modules/*/*.ko.gz | */boot/vmlinu[xz]*)
+    */lib/modules/*/*.ko | */lib/modules/*/*.ko.gz)
         is_module="1"
+        modname="${f%%.gz}"
+        modname="$(basename "$modname" .ko | tr '-' '_')"
+        echo "kmod($modname)"
         ;;
     *)
         continue

--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -33,8 +33,8 @@ while read f; do
         echo "kernel-uname-r = $version"
         builtin="$inst_prefix/lib/modules/$version/modules.builtin"
         if [ -e "$builtin" ] ; then
-                while read mod ; do
-                        echo "kmod($(basename "$mod" .ko | tr '-' '_'))"
+                while read modname ; do
+                        echo "kmod($(basename "$modname" | tr '-' '_'))"
                 done < "$builtin"
         else
                 echo "Builtin modules for $f not available in $builtin" >&2
@@ -44,8 +44,7 @@ while read f; do
     */lib/modules/*/*.ko | */lib/modules/*/*.ko.gz)
         is_module="1"
         modname="${f%%.gz}"
-        modname="$(basename "$modname" .ko | tr '-' '_')"
-        echo "kmod($modname)"
+        echo "kmod($(basename "$modname" | tr '-' '_'))"
         ;;
     *)
         continue

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -24,23 +24,23 @@ fi
 
 modules=()
 modreqs=""
-modsexp="" #matches empty line
+modsexp=""
 while read f ; do
 	case "$f" in
 		/lib/modules/*.ko) modules[${#modules[*]}]="$f" ;;
-		*/modules.builtin) while read x; do modsexp="$modsexp\\|$(basename "$x" .ko | tr '-' '_')"; done < $f ;;
+		*/modules.builtin) while read x; do modsexp="$modsexp|$(basename "$x" .ko | tr '-' '_')"; done < $f ;;
 		/usr/lib/modules-load.d/*.conf) while read x; do
 			case "$x" in
 				\#*|\;*);; #empty lines removed by grep
-				*)modreqs="$modreqs $x";;
+				*)modreqs="$modreqs $x.ko";;
 			esac
 		done < $f
 	esac
 done
-while read x ; do modsexp="$modsexp\\|$(basename "$x" .ko | tr '-' '_')" ; done << EOF
+while read x ; do modsexp="$modsexp|$(basename "$x" .ko | tr '-' '_')" ; done << EOF
 	$(echo "${modules[@]}" | tr ' ' '\n')
 EOF
-echo $modreqs | tr '- ' '_\n' | grep -ve "^\\($modsexp\\)\$" | while read x; do echo "kmod($x)" ; done
+echo $modreqs | tr ' -' '\n_' | grep -vE "^(|($modsexp).ko)\$" | while read x; do echo "kmod($x)" ; done
 
 if $is_tumbleweed; then
 	for module in "${modules[@]}"; do

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -22,7 +22,26 @@ if [ -n "$is_kernel_package" ] || ! test -e /sbin/modprobe || ! test -e /sbin/mo
     exit 0
 fi
 
-modules=($(grep -E '/lib/modules/.+\.ko$'))
+modules=()
+modreqs=""
+modsexp="" #matches empty line
+while read f ; do
+	case "$f" in
+		/lib/modules/*.ko) modules[${#modules[*]}]="$f" ;;
+		*/modules.builtin) while read x; do modsexp="$modsexp\\|$(basename "$x" .ko | tr '-' '_')"; done < $f ;;
+		/usr/lib/modules-load.d/*.conf) while read x; do
+			case "$x" in
+				\#*|\;*);; #empty lines removed by grep
+				*)modreqs="$modreqs $x";;
+			esac
+		done < $f
+	esac
+done
+while read x ; do modsexp="$modsexp\\|$(basename "$x" .ko | tr '-' '_')" ; done << EOF
+	$(echo "${modules[@]}" | tr ' ' '\n')
+EOF
+echo $modreqs | tr '- ' '_\n' | grep -ve "^\\($modsexp\\)\$" | while read x; do echo "kmod($x)" ; done
+
 if $is_tumbleweed; then
 	for module in "${modules[@]}"; do
 		flavor=${module#*/lib/modules/}

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -2,6 +2,12 @@
 
 IFS=$'\n'
 
+case "$1" in
+kernel-module-*)    ;; # Fedora kernel module package names start with
+                      # kernel-module.
+kernel*)           is_kernel_package=1 ;;
+esac
+
 is_tumbleweed=false
 
 if test "$1" = "--tumbleweed"; then
@@ -11,19 +17,60 @@ if test "$1" = "--tumbleweed"; then
     shift 2
 fi
 
-if ! $is_tumbleweed && ! test -e /sbin/modprobe; then
+if [ -n "$is_kernel_package" ] || ! test -e /sbin/modprobe || ! test -e /sbin/modinfo ; then
     cat > /dev/null
     exit 0
 fi
 
-for f in $(grep -E '/lib/modules/.+\.ko$' | grep -v '/lib/modules/[^/]*/kernel/'); do
-    flavor=${f#*/lib/modules/}
-    flavor=${flavor%%/*}
-    if $is_tumbleweed; then
-        echo "kernel-uname-r = $flavor"
-        continue
-    fi
-    flavor=${flavor##*-}
-    /sbin/modprobe --dump-modversions "$f" \
-	    | sed -r -ne "s/^0x0*([0-9a-f]+)[[:blank:]]+(.+)/ksym($flavor:\\2) = \\1/p"
-done | sort -u
+modules=($(grep -E '/lib/modules/.+\.ko$'))
+if $is_tumbleweed; then
+	for module in "${modules[@]}"; do
+		flavor=${module#*/lib/modules/}
+		flavor=${flavor%%/*}
+		flavor=${flavor##*-}
+		echo "kernel-uname-r = $flavor"
+	done
+	exit 0
+fi
+
+all_provides() {
+    for module in "${modules[@]}"; do
+	nm "$module"
+    done \
+    | sed -r -ne 's:^0*([0-9a-f]+) A __crc_(.+):\1\t\2:p' \
+    | sort -t $'\t' -k2 -u
+}
+
+all_requires() {
+    for module in "${modules[@]}"; do
+	set -- $(/sbin/modinfo -F vermagic "$module" | sed -e 's: .*::' -e q)
+	/sbin/modprobe --dump-modversions "$module" \
+	    | sed -r -e 's:^0x0*::' -e 's:$:\t'"$1"':'
+    done \
+    | sort -t $'\t' -k2 -u
+}
+
+if [ ${#modules[@]} -gt 0 ]; then
+    symset_table=$(mktemp -t ${0##*/}.XXXXX)
+    /usr/lib/rpm/symset-table | sort -t $'\t' -k 1,1 > $symset_table
+
+    join -t $'\t' -j 1 -a 2 $symset_table <(
+	# Filter out requirements that we fulfill ourself.
+	join -t $'\t' -j 2 -v 1 \
+	    <(all_requires "${modules[@]}") \
+	    <(all_provides "${modules[@]}") \
+	| awk '
+	BEGIN { FS = "\t" ; OFS = "\t" }
+	{ print $3 "/" $2 "/" $1 }
+	' \
+	| sort -t $'\t' -k 1,1 -u) \
+    | sort -u \
+    | awk '
+    { FS = "\t" ; OFS = "\t" }
+	    { split($1, arr, "/")
+	      flavor = gensub(/.*-/, "", "", arr[1]) }
+    NF == 3 { print "kernel(" flavor ":" $2 ") = " $3
+	      next }
+	    { print "ksym(" flavor ":" arr[3] ") = " arr[2] }
+    '
+fi


### PR DESCRIPTION
This resurrects code from earlier version of the script that eliminates
depends that are also provided by the package. Since the TOC. is
provided by everything this removes it.