### PR TITLE
Offer accessor for optflags without -flto

### DIFF
--- a/macros.d/macros.obs
+++ b/macros.d/macros.obs
@@ -17,4 +17,7 @@ getent group %{1} >/dev/null || /usr/sbin/groupadd -r %{1} \
 getent passwd %{1} >/dev/null || /usr/sbin/useradd -r -g %{1} -d %{2} -s %{3} -c %{4} %{1} \
 %{nil}
 
+# default optflags is with -flto, but a bunch of code does not suppor that. Offer an easy accessor to optflags without lto
+%optflagsnolto() %{lua:optflagsnolto = rpm.expand('%optflags'):gsub("-flto", ""); io.write(optflagsnolto)}
+
 


### PR DESCRIPTION
Factory is in progress of enabling -flto by default. Not all code supports this, so
those need an easy way to opt out from -flto. As such, we offer a new macro stripping
-flto from the default flags.

It can be used in a spec file the same way optflags is often used, e.g.

export CFLAGS="%{optflagsnolto}"