### PR TITLE
Added macros.d/macros.initrd

### DIFF
--- a/macros.d/macros.initrd
+++ b/macros.d/macros.initrd
@@ -1,0 +1,15 @@
+# Packages installing files and binaries that end up in the initrd should
+# call these macros in their post(trans) scriptlets to have the initrd
+# regenerated
+# See also fate#313506
+
+%regenerate_initrd_post \
+	mkdir -p /run/regenerate-initrd/ \
+	touch /run/regenerate-initrd/all \
+	%nil
+
+%regenerate_initrd_posttrans \
+	if test -x /usr/lib/module-init-tools/regenerate-initrd-posttrans; then \
+		/bin/bash -${-/e/} /usr/lib/module-init-tools/regenerate-initrd-posttrans \
+	fi \
+	%nil


### PR DESCRIPTION
Many packages need BuildRequires on suse-module-tools only for
the sake of having the "regenerate-initrd" macros defined.
These macros can't be associated with a certain package group
like the python macros. They should be in rpm-config-SUSE.