### PR TITLE
New macros for fillup, install_info and permissions

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -13,7 +13,7 @@
 %make_install           make install DESTDIR=%{?buildroot}
 %makeinstall            make DESTDIR=%{?buildroot:%{buildroot}} install
 %insserv_prereq         insserv sed
-%fillup_prereq          fillup coreutils grep diffutils
+%fillup_prereq          fillup coreutils diffutils
 %install_info_prereq    info
 
 # this script calls all scripts in /usr/lib/rpm/brp-suse.d

--- a/suse_macros.in
+++ b/suse_macros.in
@@ -15,6 +15,17 @@
 %insserv_prereq         insserv sed
 %fillup_prereq          fillup coreutils diffutils
 %install_info_prereq    info
+%fillup_requires \
+	Requires(post): coreutils fillup sed \
+	%{nil}
+%install_info_requires \
+	Requires(post): info \
+	Requires(postun): info \
+	%{nil}
+%permission_requires \
+	Requires(post): permissions \
+	Requires(verify): permissions \
+	%{nil}
 
 # this script calls all scripts in /usr/lib/rpm/brp-suse.d
 %__os_install_post  \


### PR DESCRIPTION
The current %fillup_prereq and %install_info_prereq are only packages
names, and they are often used together with a PreReq line in plenty
of Tumbleweed .spec files. Dependencies on the "permissions" package
is completely open-coded at this time.

Not in all instances is a hard PreReq required, and centralizing that
in a macro that expands to not just package names, but also the
dependency tag name, seems worthwhile. This is what the three new
macros hereby introduced are for.