### PR TITLE
Don't use bash syntax with /bin/sh

### DIFF
--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr 10 09:59:33 CEST 2019 - kukuk@suse.de
+
+- Don't use bash syntax in %install_info macro [bsc#1131957]
+
+-------------------------------------------------------------------
 Wed Jan 30 13:57:55 CET 2019 - mls@suse.de
 
 - Added macros.d/macros.initrd

--- a/suse_macros.in
+++ b/suse_macros.in
@@ -221,9 +221,8 @@
 
 # for %post
 %install_info(:-:) \
-    ALL_ARGS=(%{**}) \
     if test -x /sbin/install-info ; then \
-	/sbin/install-info "${ALL_ARGS[@]}" || : \
+	/sbin/install-info %{**} || : \
     fi ;
 
 # for %preun


### PR DESCRIPTION
If /bin/sh is not bash (like if you use busybox), %install_info fails with a syntax error.