### PR TITLE
macros: avoid emitting bashisms into scriptlets

### DIFF
--- a/macros.d/macros.initrd
+++ b/macros.d/macros.initrd
@@ -10,6 +10,6 @@
 
 %regenerate_initrd_posttrans \
 	if test -x /usr/lib/module-init-tools/regenerate-initrd-posttrans; then \
-		/bin/bash -${-/e/} /usr/lib/module-init-tools/regenerate-initrd-posttrans \
+		/bin/bash -c 'set +e; /usr/lib/module-init-tools/regenerate-initrd-posttrans' \
 	fi \
 	%nil


### PR DESCRIPTION
From @jengelh:
${//} type substitution is not understood by shells like dash.

See https://github.com/openSUSE/suse-module-tools/pull/6