### PR TITLE
Add support for compressed kernel modules

### DIFF
--- a/fileattrs/kernel.attr
+++ b/fileattrs/kernel.attr
@@ -1,2 +1,2 @@
 %__kernel_provides	%{_rpmconfigdir}/find-provides.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
-%__kernel_path		^(/lib/modules/[^/]*/kernel/.*\.ko(\.gz)?|/boot/vmlinu[xz].*)$
+%__kernel_path		^(/lib/modules/[^/]*/kernel/.*\.ko(\.gz|\.xz)?|/boot/vmlinu[xz].*)$

--- a/fileattrs/kmp.attr
+++ b/fileattrs/kmp.attr
@@ -1,4 +1,4 @@
 %__kmp_provides		%{_rpmconfigdir}/find-provides.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
 %__kmp_requires		%{_rpmconfigdir}/find-requires.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
 %__kmp_supplements	%{_rpmconfigdir}/find-supplements.ksyms
-%__kmp_path		^/lib/modules/[^/]*/(updates|extra)/.*\.ko(\.gz)?
+%__kmp_path		^/lib/modules/[^/]*/(updates|extra)/.*\.ko(\.gz|\.xz)?

--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -41,9 +41,9 @@ while read f; do
         fi
         flavor=${flavor##*-}
         ;;
-    */lib/modules/*/*.ko | */lib/modules/*/*.ko.gz)
+    */lib/modules/*/*.ko | */lib/modules/*/*.ko.[gx]z)
         is_module="1"
-        modname="${f%%.gz}"
+        modname="${f%%.[gx]z}"
         echo "kmod($(basename "$modname" | tr '-' '_'))"
         ;;
     *)
@@ -52,12 +52,14 @@ while read f; do
     if $is_tumbleweed; then
         continue
     fi
-    unzip=false
+    unzip=""
     case "$f" in
     *.gz | */boot/vmlinuz*)
-        unzip=true
+        unzip="gzip -cd";;
+    *.xz)
+        unzip="xz -cd";;
     esac
-    if $unzip && gzip -cd "$f" >"$tmp"; then
+    if test -n "$unzip" && $unzip "$f" >"$tmp"; then
         f=$tmp
     fi
     if test -z "$flavor" -a -n "$is_module" ; then

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -28,6 +28,7 @@ modsexp=""
 while read f ; do
 	case "$f" in
 		/lib/modules/*.ko) modules[${#modules[*]}]="$f" ;;
+		/lib/modules/*.ko.[gx]z) modules[${#modules[*]}]="${f%.*}" ;;
 		*/modules.builtin) while read x; do modsexp="$modsexp|$(basename "$x" .ko | tr '-' '_')"; done < $f ;;
 		/usr/lib/modules-load.d/*.conf) while read x; do
 			case "$x" in
@@ -52,9 +53,23 @@ if $is_tumbleweed; then
 	exit 0
 fi
 
+trap 'rm -f "$tmp"' EXIT
+tmp=$(mktemp)
+
 all_provides() {
     for module in "${modules[@]}"; do
-	nm "$module"
+	if [ -f "$module" ]; then
+	    nm "$module"
+	else
+	    if [ -f "$module".gz ]; then
+		gzip -cd "$module".gz > "$tmp"
+	    elif [ -f "$module".xz ]; then
+		xz -cd "$module".xz > "$tmp"
+	    else
+		continue
+	    fi
+	    nm "$tmp"
+	fi
     done \
     | sed -r -ne 's:^0*([0-9a-f]+) A __crc_(.+):\1\t\2:p' \
     | sort -t $'\t' -k2 -u
@@ -62,6 +77,15 @@ all_provides() {
 
 all_requires() {
     for module in "${modules[@]}"; do
+	if [ ! -f "$module" ]; then
+	    if [ -f "$module".gz ]; then
+		module="$module".gz
+	    elif [ -f "$module".xz ]; then
+		module="$module".xz
+	    else
+		continue
+	    fi
+	fi
 	set -- $(/sbin/modinfo -F vermagic "$module" | sed -e 's: .*::' -e q)
 	/sbin/modprobe --dump-modversions "$module" \
 	    | sed -r -e 's:^0x0*::' -e 's:$:\t'"$1"':'

--- a/scripts/find-supplements.ksyms
+++ b/scripts/find-supplements.ksyms
@@ -50,7 +50,7 @@ hexenc() {
     done
 }
 
-for module in $(grep -E '/lib/modules/.+\.ko$' | grep -v '/lib/modules/[^/]*/kernel/'); do
+for module in $(grep -E '/lib/modules/.+\.ko(\.[gx]z)?$' | grep -v '/lib/modules/[^/]*/kernel/'); do
     vermagic=$(/sbin/modinfo -F vermagic "$module")
     krel=${vermagic%% *}
     /sbin/modinfo -F alias "$module" \


### PR DESCRIPTION
This patch modifies a few scripts and attr files to support the
compressed module files.  Both gz and xz compressions are supported.

A tricky fix is the change in find-requires.ksyms.  Since the script
calls nm, we need to expand it to temporary files, just like
find-provides.ksyms already does.

Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1135854

Signed-off-by: Takashi Iwai <tiwai@suse.de>