### PR TITLE
Add support for compressed firmware files

### DIFF
--- a/scripts/firmware.prov
+++ b/scripts/firmware.prov
@@ -3,6 +3,11 @@
 
 while read instfile ; do
   case $instfile in
-    */lib/firmware/*) test -f "$instfile" && echo "firmware(${instfile##*/lib/firmware/})" ;;
+    */lib/firmware/*) test -f "$instfile" || continue ;;
+    *) continue ;;
   esac
+
+  instfile=${instfile##*/lib/firmware/}
+  instfile=${instfile%.xz}
+  echo "firmware($instfile)"
 done


### PR DESCRIPTION
The upcoming kernel will support the compressed firmware files, and
this patch corresponds to that kernel change, fixing firmware.prov to
deal with the xz-compressed firmware files as well.

Signed-off-by: Takashi Iwai <tiwai@suse.de>