### PR TITLE
find-requires.ksyms: Move modinfo and modprobe before the ksym dependency code.

### DIFF
--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -17,11 +17,6 @@ if test "$1" = "--tumbleweed"; then
     shift 2
 fi
 
-if [ -n "$is_kernel_package" ] || ! test -e /sbin/modprobe || ! test -e /sbin/modinfo ; then
-    cat > /dev/null
-    exit 0
-fi
-
 modules=()
 modreqs=""
 modsexp=""
@@ -51,6 +46,11 @@ if $is_tumbleweed; then
 		echo "kernel-uname-r = $flavor"
 	done
 	exit 0
+fi
+
+if [ -n "$is_kernel_package" ] || ! test -e /sbin/modprobe || ! test -e /sbin/modinfo ; then
+    cat > /dev/null
+    exit 0
 fi
 
 trap 'rm -f "$tmp"' EXIT


### PR DESCRIPTION
modinfo and modprobe are required to generate kABI dependencies but
generic dependecies are fine without.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>