### PR TITLE
Add _distconfdir as /usr/etc

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -8,6 +8,7 @@
 %_localstatedir         /var
 %_defaultdocdir         %{_usr}/share/doc/packages
 %_fillupdir             %{_usr}/share/fillup-templates
+%_distconfdir           %{_usr}/etc
 
 # package build macros
 %make_install           make install DESTDIR=%{?buildroot}


### PR DESCRIPTION
As discussed on opensuse-packaging, new variable to make migration to /usr/etc proposal easier.