### PR TITLE
Add macros for locale provides

### DIFF
--- a/fileattrs/locale.attr
+++ b/fileattrs/locale.attr
@@ -1,0 +1,4 @@
+%__locale_provides	%{_rpmconfigdir}/locale.prov
+%__locale_path		^%{_datadir}/locale/[^/]*/LC_MESSAGES/.*\\.mo$
+%__locale_provides_opts	%{name}
+%__locale_namespace	locale

--- a/scripts/locale.prov
+++ b/scripts/locale.prov
@@ -1,0 +1,10 @@
+#!/bin/bash
+targetpkg="${1%-lang}"
+if [ -z "$targetpkg" -o "$targetpkg" = "$1" ]; then
+	exit 0
+fi
+while read line; do
+	l="${line%%/LC_MESSAGES/*}"
+	l="${l##*/}"
+	echo "$targetpkg:$l"
+done

--- a/suse_macros.in
+++ b/suse_macros.in
@@ -267,7 +267,6 @@ Group: System/Localization \
 %{!-n:%{!-r:Requires: %{name} = %{version}}} \
 %{-r:Requires: %{-r*}} \
 Provides: %{-n:%{-n*}}%{!-n:%{name}}-lang-all = %{version} \
-Supplements: %{-n:%{-n*}}%{!-n:%{name}} \
 BuildArch: noarch \
 %description %{-n:-n %{-n*}-}lang \
 Provides translations for the \"%{name}\" package.


### PR DESCRIPTION
For packages that ship mo files, add automatic provides for the
corresponding locale instead of an unconditional Supplements.
That way the lang subpackage won't be installed on English only
installations.
The mechanism requires to stick to the common openSUSE naming
convention that a package "foo" has it's translations in a package
called "foo-lang".

Requires https://github.com/rpm-software-management/rpm/pull/575