### PR TITLE
locale.prov: also work with -locale packages

### DIFF
--- a/scripts/locale.prov
+++ b/scripts/locale.prov
@@ -1,6 +1,11 @@
 #!/bin/bash
-targetpkg="${1%-lang}"
-if [ -z "$targetpkg" -o "$targetpkg" = "$1" ]; then
+targetpkg="$1"
+if [ "${targetpkg%-lang}" != "$1" ]; then
+	targetpkg="${targetpkg%-lang}"
+elif [ "${targetpkg%-locale}" != "$1" ]; then
+	targetpkg="${targetpkg%-locale}"
+else
+	# discard input
 	cat >/dev/null
 	exit 0
 fi


### PR DESCRIPTION
There are some packages that use -locale instead of -lang for legacy
reasons, such as glibc and gcc.