### PR TITLE
Add ldconfig_scriptlets macros for RH/Fedora compatibility

### DIFF
--- a/macros.d/macros.ldconfig
+++ b/macros.d/macros.ldconfig
@@ -1,0 +1,9 @@
+%ldconfig /sbin/ldconfig
+%ldconfig_post(n:) %{?ldconfig:%post -p %ldconfig %{?*} %{-n:-n %{-n*}}\
+%end}
+%ldconfig_postun(n:) %{?ldconfig:%postun -p %ldconfig %{?*} %{-n:-n %{-n*}}\
+%end}
+%ldconfig_scriptlets(n:) %{?ldconfig:\
+%ldconfig_post %{?*} %{-n:-n %{-n*}}\
+%ldconfig_postun %{?*} %{-n:-n %{-n*}}\
+}

--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Dec 16 17:58:53 UTC 2019 - Neal Gompa <ngompa13@gmail.com>
+
+- Add ldconfig_scriptlets macros for RH/Fedora compatibility
+
+-------------------------------------------------------------------
 Tue Oct 29 11:21:54 CET 2019 - mls@suse.de
 
 - add _lto_cflags to suse_macros for now


### PR DESCRIPTION
It's just too annoying not having these, and it's basically no effort/burden to have them.