### PR TITLE
Make deprecated %install_info not fail when used within if/fi construct

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -223,11 +223,11 @@
 
 # to be removed. deprecated since 11/2019 boo#1152105
 %install_info(:-:) \
-   %{nil}
+   : # install_info deprecated in favor of file triggers
 
 # to be removed. deprecated since 11/2019 boo#1152105
 %install_info_delete(:-:) \
-   %{nil}
+   : # install_info_delete deprecated in favor of file triggers
 
 # find-supplements.ksyms parses this macro directly out of the spec file:
 %supplements_kernel_module() \


### PR DESCRIPTION
Many packages use, based on the packaging guidelines, something like this:

%preun
if [ "$1" -eq "0" ] ; then
  %install_info --delete --info-dir=%{_infodir}…
fi

With %install_info translated to %nil, this results in syntax errors by
script interpreters, as the if/fi block is empty. Work around this by
translating into a command without action.