### PR TITLE
Remove grep and diffutils from fillup_prereq, replace coreutils with file requires

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -14,7 +14,7 @@
 %make_install           make install DESTDIR=%{?buildroot}
 %makeinstall            make DESTDIR=%{?buildroot:%{buildroot}} install
 %insserv_prereq         insserv sed
-%fillup_prereq          fillup coreutils grep diffutils
+%fillup_prereq          fillup /usr/bin/mkdir /usr/bin/touch
 # to be removed. deprecated since 11/2019 boo#1152105
 %install_info_prereq    %{nil}
 


### PR DESCRIPTION
grep was never required by fillup, diffutils is not needed anymore since 2008.
Replace coreutils with files to allow usage of busybox.