### PR TITLE
Switch compression for binary package payloads to Zstandard

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -299,3 +299,6 @@ Provides translations for the \"%{name}\" package.
 
 # avoid overwriting files that didn't actually change on disk
 %_minimize_writes	1
+
+# Use Zstandard compression for binary payloads
+%_binary_payload	w19.zstdio


### PR DESCRIPTION
Since openSUSE Leap 15.2 can read and install RPMs using Zstandard compression,
we can make the switch in Factory, as Fedora has done.

Cf. https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression

Resolves #11 