### PR TITLE
Don't limit locale match to /usr/share/locale

### DIFF
--- a/fileattrs/locale.attr
+++ b/fileattrs/locale.attr
@@ -1,4 +1,4 @@
 %__locale_provides	%{_rpmconfigdir}/locale.prov
-%__locale_path		^%{_datadir}/locale/[^/]*/LC_MESSAGES/.*\\.mo$
+%__locale_path		/locale/[^/]*/LC_MESSAGES/.*\\.mo$
 %__locale_provides_opts	%{name}
 %__locale_namespace	locale


### PR DESCRIPTION
As per discussion on the packaging list there are several packages that
install their mo files into a custom location rather than
/usr/share/locale. So relax the regexp to also catch those.