### PR TITLE
Define a global %_firmwaredir

### DIFF
--- a/fileattrs/firmware.attr
+++ b/fileattrs/firmware.attr
@@ -1,2 +1,2 @@
 %__firmware_provides	%{_rpmconfigdir}/firmware.prov
-%__firmware_path	/lib/firmware/
+%__firmware_path	%{_firmwaredir}

--- a/suse_macros.in
+++ b/suse_macros.in
@@ -9,6 +9,7 @@
 %_defaultdocdir         %{_usr}/share/doc/packages
 %_fillupdir             %{_usr}/share/fillup-templates
 %_distconfdir           %{_usr}/etc
+%_firmwaredir           /lib/firmware
 
 # package build macros
 %make_install           make install DESTDIR=%{?buildroot}


### PR DESCRIPTION
So far all packages hardcode the path themselves. A global define will
help moving all packages shipping firmware in case that turns out to
be needed (boo#1029961)