### PR TITLE
find-requires.ksyms: actually generate modules-load.d dependencies

### DIFF
--- a/fileattrs/modulesload.attr
+++ b/fileattrs/modulesload.attr
@@ -1,0 +1,2 @@
+%__modulesload_requires		%{_rpmconfigdir}/find-requires.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
+%__modulesload_path		^/usr/lib/modules-load.d/.*\.conf$


### PR DESCRIPTION
We've got modules-load.d style dependenices since 52cc7dc, but they
aren't actually generated because we're lacking a fileattr for
modules-load.d files.

Add it.

(Note: I still need to test this).