### PR TITLE
find-requires.ksyms: use "if kernel" conditional for modules-load.d

### DIFF
--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -36,7 +36,7 @@ done
 while read x ; do modsexp="$modsexp|$(basename "$x" .ko | tr '-' '_')" ; done << EOF
 	$(echo "${modules[@]}" | tr ' ' '\n')
 EOF
-echo $modreqs | tr ' -' '\n_' | grep -vE "^(|($modsexp).ko)\$" | while read x; do echo "kmod($x)" ; done
+echo $modreqs | tr ' -' '\n_' | grep -vE "^(|($modsexp).ko)\$" | while read x; do echo "(kmod($x) if kernel)" ; done
 
 if $is_tumbleweed; then
 	for module in "${modules[@]}"; do


### PR DESCRIPTION
Without this, kmod-dependencies may blow up e.g. container images. This has happened in the past, and has caused the kmod requires to have to be taken back for both factory and SLE.

SLE architects are tackling this issue now with the conditional dependency.
This is obviously related to #36, which should rather not be pushed to Factory without this fix.