### PR TITLE
Backport rpm 4.15 macros

### DIFF
--- a/macros.d/macros.rpm415
+++ b/macros.d/macros.rpm415
@@ -1,0 +1,33 @@
+# C compiler flags.  This is traditionally called CFLAGS in makefiles.
+# Historically also available as %%{optflags}, and %%build sets the
+# environment variable RPM_OPT_FLAGS to this value.
+%build_cflags %{optflags}
+
+# C++ compiler flags.  This is traditionally called CXXFLAGS in makefiles.
+%build_cxxflags %{optflags}
+
+# C++ compiler flags.  This is traditionally called CXXFLAGS in makefiles.
+%build_cxxflags %{optflags}
+
+# Fortran compiler flags.  Makefiles use both FFLAGS and FCFLAGS as
+# the corresponding variable names.
+%build_fflags %{optflags} %{?_fmoddir:-I%{_fmoddir}}
+
+# Link editor flags.  This is usually called LDFLAGS in makefiles.
+#%build_ldflags -Wl,-z,relro %{?_lto_cflags}
+
+# Expands to shell code to seot the compiler/linker environment
+# variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have
+# not been set already.
+%set_build_flags \
+  CFLAGS="${CFLAGS:-%{?build_cflags}}" ; export CFLAGS ; \
+  CXXFLAGS="${CXXFLAGS:-%{?build_cxxflags}}" ; export CXXFLAGS ; \
+  FFLAGS="${FFLAGS:-%{?build_fflags}}" ; export FFLAGS ; \
+  FCFLAGS="${FCFLAGS:-%{?build_fflags}}" ; export FCFLAGS ; \
+  LDFLAGS="${LDFLAGS:-%{?build_ldflags}}" ; export LDFLAGS
+
+%_smp_build_ncpus %([ -z "$RPM_BUILD_NCPUS" ] \\\
+ 	&& RPM_BUILD_NCPUS="`/usr/bin/getconf _NPROCESSORS_ONLN`"; \\\
+        ncpus_max=%{?_smp_ncpus_max}; \\\
+        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$RPM_BUILD_NCPUS" -gt "$ncpus_max" ]; then RPM_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        echo "$RPM_BUILD_NCPUS";)

--- a/package/rpm-config-SUSE.changes
+++ b/package/rpm-config-SUSE.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug  2 08:47:06 UTC 2021 - Frederic Crozat <fcrozat@suse.com>
+
+- Add rpm 4.15 macros to be used on older SLE / openSUSE Leap
+  (jsc#SLE-20017).
+
+-------------------------------------------------------------------
 Wed Mar  3 16:59:22 UTC 2021 - Ludwig Nussel <lnussel@suse.de>
 
 - Prepare usrmerge (boo#1029961): add %usrmerged macro

--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -73,7 +73,7 @@ cp -a macros.d %{buildroot}%{_rpmconfigdir}
 
 # Only ship macros.rpm415 for old openSUSE Leap / SLE
 %if 0%{?suse_version} >= 1550
-rm -f macros.d/macros.rpm415
+rm -f %{buildroot}%{_rpmconfigdir}/macros.rpm415
 %endif
 
 

--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -24,7 +24,7 @@ Summary:        SUSE specific RPM configuration files
 License:        GPL-2.0-or-later
 Group:          System/Packages
 URL:            https://github.com/openSUSE/rpm-config-SUSE
-Source:         %{name}-%{version}.tar.gz
+Source:         %{name}-%{version}.tar.xz
 
 # RPM owns the directories we need
 Requires:       rpm

--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -71,6 +71,12 @@ cp -a fileattrs %{buildroot}%{_rpmconfigdir}
 cp -a scripts/* %{buildroot}%{_rpmconfigdir}
 cp -a macros.d %{buildroot}%{_rpmconfigdir}
 
+# Only ship macros.rpm415 for old openSUSE Leap / SLE
+%if 0%{?suse_version} >= 1550
+rm -f macros.d/macros.rpm415
+%endif
+
+
 %files
 %license COPYING
 %doc README.md


### PR DESCRIPTION
Allow to build Factory packages on older SLE / openSUSE Leap (jsc#SLE-20017).