### PR TITLE
Allow locale directory to be named "locales" too

### DIFF
--- a/fileattrs/locale.attr
+++ b/fileattrs/locale.attr
@@ -1,4 +1,4 @@
 %__locale_provides	%{_rpmconfigdir}/locale.prov
-%__locale_path		/locale/[^/]*/LC_MESSAGES/.*\\.mo$
+%__locale_path		/locales\?/[^/]*/LC_MESSAGES/.*\\.mo$
 %__locale_provides_opts	%{name}
 %__locale_namespace	locale


### PR DESCRIPTION
Some packages that use custom locale directories use
"locales" instead of "locale" so .mo files have to
be found there too.

This is part of the fix for
https://bugzilla.opensuse.org/show_bug.cgi?id=1190251