### PR TITLE
find-provides.ksyms: fix "xz -cd: command not found"

### DIFF
--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -62,7 +62,7 @@ while read f; do
     *.zst)
         unzip="zstd -cd";;
     esac
-    if test -n "$unzip" && $unzip "$f" >"$tmp"; then
+    if test -n "$unzip" && (IFS=" "; $unzip "$f" >"$tmp"); then
         f=$tmp
     fi
     if test -z "$flavor" -a -n "$is_module" ; then


### PR DESCRIPTION
Fixes: /usr/lib/rpm/find-provides.ksyms: line 65: xz -cd: command not found

The problem is that IFS is set to $'\n', and thus if unzip is
"xz -dc", the shell will not do word splitting on it, treating
"xz -dc" as a single word which doesn't resolve to a command.
