### PR TITLE
find-provides.ksyms: Fix compressed modules.

### DIFF
--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -56,13 +56,13 @@ while read f; do
     unzip=""
     case "$f" in
     *.gz | */boot/vmlinuz*)
-        unzip="gzip -cd";;
+        unzip="gzip";;
     *.xz)
-        unzip="xz -cd";;
+        unzip="xz";;
     *.zst)
-        unzip="zstd -cd";;
+        unzip="zstd";;
     esac
-    if test -n "$unzip" && $unzip "$f" >"$tmp"; then
+    if test -n "$unzip" && $unzip -cd "$f" >"$tmp"; then
         f=$tmp
     fi
     if test -z "$flavor" -a -n "$is_module" ; then


### PR DESCRIPTION
Because IFS is set to \n the unzip variable is not split at space
resulting in

/usr/lib/rpm/find-provides.ksyms: line 65: xz -cd: command not found

Move the -cd argument to the unzip invocation so that there is no need
to split the variable.

Fixes: #45
Fixes: 6cd29a8 ("Add support for compressed kernel modules")
Signed-off-by: Michal Suchanek <msuchanek@suse.de>