### PR TITLE
find-provides.ksyms: Do not set IFS - it is not needed for anything.

### DIFF
--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -1,7 +1,5 @@
 #! /bin/bash
 
-IFS=$'\n'
-
 is_tumbleweed=false
 
 if test "$1" = "--tumbleweed"; then


### PR DESCRIPTION
Changing IFS makes the following code behave unexpectedly and it already
caused #45. Use the default IFS.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>