### PR TITLE
locale.attr: Match all files inside LC_MESSAGES (boo#1194865)

### DIFF
--- a/fileattrs/locale.attr
+++ b/fileattrs/locale.attr
@@ -1,4 +1,4 @@
 %__locale_provides	%{_rpmconfigdir}/locale.prov
-%__locale_path		/locales\?/[^/]*/LC_MESSAGES/.*\\.mo$
+%__locale_path		/locales\?/[^/]*/LC_MESSAGES/.*$
 %__locale_provides_opts	%{name}
 %__locale_namespace	locale


### PR DESCRIPTION
There are more than just gettext catalogs, like Qt translation files (.qm).