### PR TITLE
Redefine %__debug_install_post to simplify debuginfo setup

### DIFF
--- a/macros.d/macros.debuginfo
+++ b/macros.d/macros.debuginfo
@@ -1,0 +1,44 @@
+# Whether build-ids should be made unique between package version/releases
+# when generating debuginfo packages. If set to 1 this will pass
+# --build-id-seed "%{VERSION}-%{RELEASE}" to find-debuginfo.sh which will
+# pass it onto debugedit --build-id-seed to be used to prime the build-id
+# note hash.
+%_unique_build_ids      0
+
+# Do not recompute build-ids but keep whatever is in the ELF file already.
+# Cannot be used together with _unique_build_ids (which forces recomputation).
+# Defaults to undefined (unset).
+%_no_recompute_build_ids 1
+
+# Whether .debug files should be made unique between package version,
+# release and architecture. If set to 1 this will pass
+# --unique-debug-suffix "-%{VERSION}-%{RELEASE}.%{_arch} find-debuginfo.sh
+# to create debuginfo files which end in -<ver>-<rel>.<arch>.debug
+# Requires _unique_build_ids.
+%_unique_debug_names    0
+
+# Whether the /usr/debug/src/<package> directories should be unique between
+# package version, release and architecture. If set to 1 this will pass
+# --unique-debug-src-base "%{name}-%{VERSION}-%{RELEASE}.%{_arch}" to
+# find-debuginfo.sh to name the directory under /usr/debug/src as
+# <name>-<ver>-<rel>.<arch>.
+%_unique_debug_srcs     0
+
+# we need to overwrite the full macro as we can't undefine in macro.d and
+# rpm has a version that will create "unique" build ids by seeding the %RELEASE
+# into the build id which in return leaks into the binaries and their hmac
+# files in the end making it impossible for build-compare to check equality
+%__debug_install_post   \
+    %{__find_debuginfo} \\\
+    %{?_smp_build_ncpus:-j%{_smp_build_ncpus}} \\\
+    %{?_missing_build_ids_terminate_build:--strict-build-id} \\\
+    %{?_no_recompute_build_ids:-n} \\\
+    %{?_include_minidebuginfo:-m} \\\
+    %{?_include_gdb_index:-i} \\\
+    %{?_find_debuginfo_dwz_opts} \\\
+    %{lua:if posix.access(rpm.expand("%_sourcedir/baselibs.conf"), "r") then print("--dwz-single-file-mode") end} \\\
+    %{?_find_debuginfo_opts} \\\
+    %{?_debugsource_packages:-S debugsourcefiles.list} \\\
+    "%{_builddir}/%{?buildsubdir}"\
+%{nil}
+


### PR DESCRIPTION
We don't support parallel installation of the same debuginfo - and so
don't patch the binaries to create unique build ids. Unfortunately
we can't just define the macros affecting the behaviour of
debug_install_post as the version in rpm triggers on defined macros
and we can't undefine it