### PR TITLE
Fix SLE sbat macros used on Leap (bsc#1198458)

### DIFF
--- a/macros.d/macros.sbat
+++ b/macros.d/macros.sbat
@@ -1,0 +1,16 @@
+# Common SBAT values for secure boot
+# https://github.com/rhboot/shim/blob/main/SBAT.md
+
+# Common
+%sbat_distro_url      mailto:security@suse.de
+
+# openSUSE
+%sbat_distro_opensuse opensuse
+%sbat_distro_summary_opensuse  The openSUSE Project
+
+# SLE
+%sbat_distro_sle          sle
+%sbat_distro_summary_sle  SUSE Linux Enterprise
+
+%sbat_distro          %{?is_opensuse:%{sbat_distro_opensuse}}%{!?is_opensuse:%{sbat_distro_sle}}
+%sbat_distro_summary  %{?is_opensuse:%{sbat_distro_summary_opensuse}}%{!?is_opensuse:%{sbat_distro_summary_sle}}

--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -67,20 +67,6 @@ cat <<EOF > macros.d/macros.opensuse
 EOF
 %endif
 
-cat <<EOF > macros.d/macros.sbat
-# Common SBAT values for secure boot
-# https://github.com/rhboot/shim/blob/main/SBAT.md
-
-%if 0%{?is_opensuse}
-%%sbat_distro          opensuse
-%%sbat_distro_summary  The openSUSE Project
-%else
-%%sbat_distro          sle
-%%sbat_distro_summary  SUSE Linux Enterprise
-%endif
-%%sbat_distro_url      mailto:security@suse.de
-EOF
-
 %install
 # Install SUSE vendor macros and rpmrc
 mkdir -p %{buildroot}%{_rpmconfigdir}/suse


### PR DESCRIPTION
Define all macros in macros.sbat with suffixes and then check at runtime whether %is_opensuse is true

https://build.opensuse.org/package/rdiff/openSUSE:Factory/shim?linkrev=base&rev=102