### PR TITLE
%requires_eq|ge(): Report error if package version cannot be determined

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -292,8 +292,8 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 %py_sitedir             %{py_libdir}/site-packages
 
 # dropped from rpm package
-%requires_eq() %(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
-%requires_ge() %(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
+%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
+%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
 %__perl			/usr/bin/perl
 
 # to be removed when no longer needed (when gcc-10.1 is in Factory)


### PR DESCRIPTION
The %requires_eq|ge() macros silently dropped dependencies when the package whose dependency was to be determined could not be found. Thus the missing dependency could go undetected.
Make sure an error is reported in such cases.

Signed-off-by: Egbert Eich <eich@suse.com>