### PR TITLE
Add %no_lang_C

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -267,6 +267,9 @@ BuildArch: noarch \
 %description %{-n:-n %{-n*}-}lang \
 Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 
+# Ignore C lang file from lang package file list
+%no_lang_C --without-C
+
 # package version comparison macros
 
 # compare two versions, returns -1, 0, 1, ~~~


### PR DESCRIPTION
Even though the functionality is created in RPM, it doesn't strictly require this macro so should exist here