### PR TITLE
scripts: Do full ksyms dependencies on Tumbleweed

### DIFF
--- a/fileattrs/kernel.attr
+++ b/fileattrs/kernel.attr
@@ -1,2 +1,2 @@
-%__kernel_provides	%{_rpmconfigdir}/find-provides.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
+%__kernel_provides	%{_rpmconfigdir}/find-provides.ksyms
 %__kernel_path		^((/usr)?/lib/modules/[^/]*/kernel/(.*\.ko(\.gz|\.xz|\.zst)?|vmlinu[xz])|/boot/vmlinu[xz].*)$

--- a/fileattrs/kmp.attr
+++ b/fileattrs/kmp.attr
@@ -1,4 +1,4 @@
-%__kmp_provides		%{_rpmconfigdir}/find-provides.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
-%__kmp_requires		%{_rpmconfigdir}/find-requires.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
+%__kmp_provides		%{_rpmconfigdir}/find-provides.ksyms
+%__kmp_requires		%{_rpmconfigdir}/find-requires.ksyms
 %__kmp_supplements	%{_rpmconfigdir}/find-supplements.ksyms
 %__kmp_path		^(/usr)?/lib/modules/[^/]*/(updates|extra)/.*\.ko(\.gz|\.xz|\.zst)?

--- a/fileattrs/modulesload.attr
+++ b/fileattrs/modulesload.attr
@@ -1,2 +1,2 @@
-%__modulesload_requires		%{_rpmconfigdir}/find-requires.ksyms --tumbleweed %{?sle_version:0}%{!?sle_version:1}
+%__modulesload_requires		%{_rpmconfigdir}/find-requires.ksyms
 %__modulesload_path		^(/usr)?/lib/modules-load.d/.*\.conf$

--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -1,19 +1,7 @@
 #! /bin/bash
 
-is_tumbleweed=false
-
-if test "$1" = "--tumbleweed"; then
-    if test "$2" -gt 0; then
-        is_tumbleweed=true
-    fi
-    shift 2
-fi
-
-if ! $is_tumbleweed; then
-    trap 'rm -f "$tmp"' EXIT
-    tmp=$(mktemp)
-fi
-
+trap 'rm -f "$tmp"' EXIT
+tmp=$(mktemp)
 
 while read f; do
     test -e "$f" || continue
@@ -48,9 +36,6 @@ while read f; do
     *)
         continue
     esac
-    if $is_tumbleweed; then
-        continue
-    fi
     unzip=""
     case "$f" in
     *.gz | */boot/vmlinuz*)

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -8,15 +8,6 @@ kernel-module-*)    ;; # Fedora kernel module package names start with
 kernel*)           is_kernel_package=1 ;;
 esac
 
-is_tumbleweed=false
-
-if test "$1" = "--tumbleweed"; then
-    if test "$2" -gt 0; then
-        is_tumbleweed=true
-    fi
-    shift 2
-fi
-
 modules=()
 modreqs=""
 modsexp=""
@@ -38,15 +29,6 @@ while read x ; do modsexp="$modsexp|$(basename "$x" .ko | tr '-' '_')" ; done <<
 	$(echo "${modules[@]}" | tr ' ' '\n')
 EOF
 echo $modreqs | tr ' -' '\n_' | grep -vE "^(|($modsexp).ko)\$" | while read x; do echo "(kmod($x) if kernel)" ; done
-
-if $is_tumbleweed; then
-	for module in "${modules[@]}"; do
-		version=${module#*/lib/modules/}
-		version=${version%%/*}
-		echo "kernel-uname-r = $version"
-	done
-	exit 0
-fi
 
 if [ -n "$is_kernel_package" ] || ! test -e /sbin/modprobe || ! test -e /sbin/modinfo ; then
     cat > /dev/null


### PR DESCRIPTION
With this we will get our ksym provides scripting tested in Factory, avoid invalid version warning for kernel-uname-r, and avoid wrong requires when modules are not installed in the module directory of the kernel they are built for.