### PR TITLE
find-provides.ksyms: Fix ksym provides on Tumbleweed/ALP

### DIFF
--- a/scripts/find-provides.ksyms
+++ b/scripts/find-provides.ksyms
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 trap 'rm -f "$tmp"' EXIT
-tmp=$(mktemp)
+tmp=$(mktemp --suffix=.ko)
 
 while read f; do
     test -e "$f" || continue


### PR DESCRIPTION
The find-provides.ksyms uncompresses the kernel module into a temporary file to pass it to the ksym-provides tool that does not support compression.

modinfo tool form current kmod version refuses to provide information for files not ending in .ko.

Add .ko suffix to the temporary file.

Alternatives:
 - use modinfo on the compressed file
 - revert the modinfo change that enforces module filenames ending in .ko