### PR TITLE
set_permissions: handle chkstat failure more grateful

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -47,7 +47,7 @@
 
 %set_permissions(f:) \
   if [ -x /usr/bin/chkstat ]; then \
-    /usr/bin/chkstat -n --set --system %{**} \
+    /usr/bin/chkstat -n --set --system %{**} || : \
   fi \
   %nil
 


### PR DESCRIPTION
* %set_permission should not bail out if chkstat fails, it should handle the failure more grateful. See bsc#1219736.
* Calling `zypper --install-root` could cause a failure with chkstat due to an unavailability of /proc. Instead of abort an installation / update of an RPM that will result in an undefined state for the system, ignore the error message. The user can fix this by calling chkstat themself.