### PR TITLE
lang_package: Add 'basename' option

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -255,7 +255,7 @@
 %nil
 
 # Template for lang sub-package.
-%lang_package(n:r:) \
+%lang_package(n:r:b:) \
 %package %{-n:-n %{-n*}-}lang \
 Summary: Translations for package %{-n:%{-n*}}%{!-n:%{name}} \
 Group: System/Localization \
@@ -263,6 +263,8 @@ Group: System/Localization \
 %{!-n:%{!-r:Requires: %{name} = %{version}}} \
 %{-r:Requires: %{-r*}} \
 Provides: %{-n:%{-n*}}%{!-n:%{name}}-lang-all = %{version} \
+%{-b:Provides: %{-b*}-lang = %{version}} \
+%{-b:Conflicts: %{-b*}-lang} \
 BuildArch: noarch \
 %description %{-n:-n %{-n*}-}lang \
 Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.


### PR DESCRIPTION
Packages which use %lang_package and are based on a library will conflict with each other in filelist but have differing names which will trigger an installcheck error

Provide an option to provide RPM deps with the helper
The intention is for the 'basename' to be the name of installed lang files to provide continuity, although for fast fixes of this issue the old package name can be used