### PR TITLE
Strip the explicit /bin/bash dependency for ksym macros

### DIFF
--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -29,6 +29,8 @@ BuildRequires:  zstd
 #!BuildIgnore:  rpm-config-SUSE
 # RPM owns the directories we need
 Requires:       rpm
+# ignore the explicit bash requires from the kernel mod scripts
+%define __requires_exclude ^/bin/bash$
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
These are only needed during kernel module builds, but the scripts already require a dozen other tools (binutils etc) that are not required.