### PR TITLE
handle chkstat being renamed to permctl

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -46,13 +46,19 @@
 %is_plus %(if test -f /.buildenv ; then source /.buildenv ; if [[ "$BUILD_BASENAME" == *+kde ]] ; then echo 1 ; else echo 0 ; fi ; else echo 0 ; fi)
 
 %set_permissions(f:) \
-  if [ -x /usr/bin/chkstat ]; then \
+  if [ -x /usr/bin/permctl ]; then \
+    /usr/bin/permctl -n --set --system %{**} || : \
+  elif [ -x /usr/bin/chkstat ]; then \
     /usr/bin/chkstat -n --set --system %{**} || : \
   fi \
   %nil
 
 %verify_permissions(e:f:) \
-   /usr/bin/chkstat -n --warn --system %{**} 1>&2 \
+   if [ -x /usr/bin/permctl ]; then \
+     /usr/bin/permctl -n --warn --system %{**} 1>&2 \
+   else \
+     /usr/bin/chkstat -n --warn --system %{**} 1>&2 \
+   fi \
    %nil
 
 %suse_update_libdir() \


### PR DESCRIPTION
chkstat still works, but reports
  WARNING: `chkstat` has been renamed to `permctl`
on each call.

Adjust the permissions macro to prefer permctl when found, and
fall back to chkstat otherwise
