### PR TITLE
Revert "%requires_eq|ge(): Report error if package version cannot be determined"

### DIFF
--- a/suse_macros.in
+++ b/suse_macros.in
@@ -284,8 +284,8 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 %py_sitedir             %{py_libdir}/site-packages
 
 # dropped from rpm package
-%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
-%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
+%requires_eq() %(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
+%requires_ge() %(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not")
 %__perl			/usr/bin/perl
 
 # we use the macro as one can easily override it and thus disable LTO for a particular package


### PR DESCRIPTION
Reverts openSUSE/rpm-config-SUSE#64

This implementation conflicts with python-singlespec, which rewrites parts of the spec files (e.g Requires: python-FOO becomes python311-FOO in python311-* packages)