### PR TITLE
%requires_eq|ge(): Fix multiline output

### DIFF
--- a/suse/macros
+++ b/suse/macros
@@ -278,8 +278,8 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 %py_sitedir             %{py_libdir}/site-packages
 
 # dropped from rpm package
-%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
-%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo $t)}
+%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo "$t")}
+%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo "$t")}
 %__perl			/usr/bin/perl
 
 # we use the macro as one can easily override it and thus disable LTO for a particular package


### PR DESCRIPTION
In the expansion of the %requires_eq macro the output is stored in a variable and then it's printed with "echo". This patch adds quotes to the variable so breaklines are not removed from the final output.

See https://bugzilla.opensuse.org/show_bug.cgi?id=1233513