### PR TITLE
Split the SUSE distribution version macros to a separate file

### DIFF
--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -53,7 +53,7 @@ sed -e 's/@suse_version@/%{?suse_version}%{!?suse_version:0}/' \
 %else
     -e '/@sle_version@/d' \
 %endif
-  < suse_macros.in > suse_macros
+  < suse_dist_macros.in > macros.d/macros.susedist
 
 
 %if 0%{?is_opensuse}
@@ -69,8 +69,7 @@ EOF
 
 %install
 # Install SUSE vendor macros and rpmrc
-mkdir -p %{buildroot}%{_rpmconfigdir}/suse
-cp -a suse_macros %{buildroot}%{_rpmconfigdir}/suse/macros
+cp -a suse %{buildroot}%{_rpmconfigdir}
 
 # Install vendor dependency generators
 cp -a fileattrs %{buildroot}%{_rpmconfigdir}

--- a/suse/macros
+++ b/suse/macros
@@ -226,12 +226,6 @@
 %supplements_kernel_module() \
     %{expand:%(if ! rpm -q kernel-syms > /dev/null; then echo "%fail Please add the kernel-syms package to BuildRequires"; fi)}
 
-%suse_version @suse_version@
-%sles_version @sles_version@
-%ul_version @ul_version@
-%is_opensuse @is_opensuse@
-%sle_version @sle_version@
-
 %do_profiling 1
 %cflags_profile_generate -fprofile-update=atomic -fprofile-generate
 %cflags_profile_feedback -fprofile-use

--- a/suse_dist_macros.in
+++ b/suse_dist_macros.in
@@ -1,0 +1,6 @@
+%suse_version @suse_version@
+%sles_version @sles_version@
+%ul_version @ul_version@
+%is_opensuse @is_opensuse@
+%sle_version @sle_version@
+%leap_version @leap_version@


### PR DESCRIPTION
This simplifies the structure and prepares for future cleanups of the macros.