### PR TITLE
kmp.attr: Run scripts for all modules (bsc#1237308).

### DIFF
--- a/fileattrs/kmp.attr
+++ b/fileattrs/kmp.attr
@@ -1,4 +1,4 @@
 %__kmp_provides		%{_rpmconfigdir}/find-provides.ksyms
 %__kmp_requires		%{_rpmconfigdir}/find-requires.ksyms
 %__kmp_supplements	%{_rpmconfigdir}/find-supplements.ksyms
-%__kmp_path		^(/usr)?/lib/modules/[^/]*/(updates|extra)/.*\.ko(\.gz|\.xz|\.zst)?
+%__kmp_path		^(/usr)?/lib/modules/.*\.ko(\.gz|\.xz|\.zst)?


### PR DESCRIPTION
The match in kmp.attr tries to match only KMP modules and exclude kernel modules. This does not work well because the regular expression is too restrictive. The scripts detect and exclude kernel modules anyway, just run them for all modules indiscriminately.