### PR TITLE
Define %jobs as variable (boo#1237231)

### DIFF
--- a/suse/macros
+++ b/suse/macros
@@ -291,6 +291,11 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 # SUSE expects bash for building
 %_buildshell           /usr/bin/bash
 
+# Tell obs-build to not use a constant in %jobs for reproducible builds
+# boo#1237231 https://github.com/rpm-software-management/rpm/issues/2343
+# note: $RPM_BUILD_NCPUS is only available in rpm versions after 2022-11-09
+%jobs ${RPM_BUILD_NCPUS}
+
 # Expands to shell code to seot the compiler/linker environment
 # variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have
 # not been set already.


### PR DESCRIPTION
Define `%jobs` as variable ([boo#1237231](https://bugzilla.suse.com/show_bug.cgi?id=1237231)) for reproducible builds.
Without this patch, obs-build would set %jobs to a constant that depends on the number of cores assigned to a build worker VM, making it hard to verify build results.