### PR TITLE
Create the directory for rpm macros installation in install

### DIFF
--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -69,6 +69,7 @@ EOF
 
 %install
 # Install SUSE vendor macros and rpmrc
+install -d -m 0755 %{buildroot}%{_rpmconfigdir}
 cp -a suse %{buildroot}%{_rpmconfigdir}
 
 # Install vendor dependency generators


### PR DESCRIPTION
without that, the next line fails with "directory does not exist"