### PR TITLE
Revert "Define %jobs as variable (boo#1237231)"

### DIFF
--- a/suse/macros
+++ b/suse/macros
@@ -291,11 +291,6 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 # SUSE expects bash for building
 %_buildshell           /usr/bin/bash
 
-# Tell obs-build to not use a constant in %jobs for reproducible builds
-# boo#1237231 https://github.com/rpm-software-management/rpm/issues/2343
-# note: $RPM_BUILD_NCPUS is only available in rpm versions after 2022-11-09
-%jobs ${RPM_BUILD_NCPUS}
-
 # Expands to shell code to seot the compiler/linker environment
 # variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have
 # not been set already.


### PR DESCRIPTION
Reverts openSUSE/rpm-config-SUSE#83

the expansion of `%jobs` to an environment variable does not work everywhere (for example not in `%if` statements) and `%jobs` is a deprecated suse-only invention. users should use `%_smp_mflags` instead.
