### PR TITLE
packaging: replace @leap_version@ in suse_dist_macros.in

### DIFF
--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -45,6 +45,7 @@ openSUSE distribution families.
 sed -e 's/@suse_version@/%{?suse_version}%{!?suse_version:0}/' \
     -e 's/@sles_version@/%{?sles_version}%{!?sles_version:0}/' \
     -e 's/@ul_version@/%{?ul_version}%{!?ul_version:0}/' \
+    -e 's/@leap_version@/%{?leap_version}%{!?leap_version:0}/' \
     -e '/@is_opensuse@%{?is_opensuse:nomatch}/d' \
     -e 's/@is_opensuse@/%{?is_opensuse}%{!?is_opensuse:0}/' \
 %if 0%{?is_opensuse}


### PR DESCRIPTION
PR https://github.com/openSUSE/rpm-config-SUSE/pull/81 added leap_version to the listed distros - but the relevant code in the .spec file to set this to 0 in case leap_version is not defined in prjconf, was missing, resulting in the now published/installed file to contain

```
%leap_version @leap_version@
```

This in turn results in errors in packages like 'knot':
`[   13s] error: /home/abuild/rpmbuild/SOURCES/knot.spec:67: bad %if condition:  01699 > 1320 || 0@leap_version@ == 420300`