### PR TITLE
Add macros for reproducible-builds

### DIFF
--- a/macros.d/macros.reproducible-builds
+++ b/macros.d/macros.reproducible-builds
@@ -1,0 +1,3 @@
+# Reproducible builds
+%_buildtime %{getenv:SOURCE_DATE_EPOCH_MTIME}
+%_buildhost reproducible

--- a/package/rpm-config-SUSE.spec
+++ b/package/rpm-config-SUSE.spec
@@ -37,6 +37,13 @@ BuildArch:      noarch
 This package contains the RPM configuration data for the SUSE and
 openSUSE distribution families.
 
+%package reproducible-builds
+Summary:        RPM macros for reproducible-builds
+
+%description reproducible-builds
+This package contains the RPM macros for normalizing
+more details about a build (e.g. buildhost, buildtime)
+
 %prep
 %setup -q
 
@@ -83,6 +90,7 @@ cp -a macros.d %{buildroot}%{_rpmconfigdir}
 %doc README.md
 %{_rpmconfigdir}/suse/
 %{_rpmconfigdir}/macros.d/macros.*
+%exclude %{_rpmconfigdir}/macros.d/macros.reproducible-builds
 %{_rpmconfigdir}/fileattrs/*
 %{_rpmconfigdir}/brp-suse
 %{_rpmconfigdir}/firmware.prov
@@ -92,5 +100,8 @@ cp -a macros.d %{buildroot}%{_rpmconfigdir}
 %{_rpmconfigdir}/find-provides.ksyms
 %{_rpmconfigdir}/find-requires.ksyms
 %{_rpmconfigdir}/find-supplements.ksyms
+
+%files reproducible-builds
+%{_rpmconfigdir}/macros.d/macros.reproducible-builds
 
 %changelog

--- a/suse/macros
+++ b/suse/macros
@@ -230,6 +230,9 @@
 %cflags_profile_generate -fprofile-update=atomic -fprofile-generate
 %cflags_profile_feedback -fprofile-use
 
+# Reproducible builds
+%build_mtime_policy clamp_to_buildtime
+
 %suse_install_update_message() \
     install -D -m 644 %1 %buildroot/var/adm/update-messages/%{name}-%{version}-%{release}-%(basename %1).txt \
 %nil


### PR DESCRIPTION
Some moved from prjconf,
some added for rpm-4.20's new way of doing things
and some dropped that should no more be needed with 4.20