### PR TITLE
kmp.attr: Exclude kernel modules from kmp dependency generation

### DIFF
--- a/fileattrs/kernel.attr
+++ b/fileattrs/kernel.attr
@@ -1,2 +1,4 @@
-%__kernel_provides	%{_rpmconfigdir}/find-provides.ksyms
-%__kernel_path		^((/usr)?/lib/modules/[^/]*/kernel/(.*\.ko(\.gz|\.xz|\.zst)?|vmlinu[xz])|/boot/vmlinu[xz].*)$
+%__kernel_provides	%{_rpmconfigdir}/find-provides.ksyms %name
+%__kernel_path		^((/usr)?/lib/modules/^[/]*/(.*\.ko|vmlinux)(\.gz|\.xz|\.zst)?|/boot/vmlinux.*)$
+%__kernel_requires		%{_rpmconfigdir}/find-requires.ksyms %name
+%__kernel_supplements	%{_rpmconfigdir}/find-supplements.ksyms %name

--- a/fileattrs/kmp.attr
+++ b/fileattrs/kmp.attr
@@ -1,5 +1,0 @@
-%__kmp_provides		%{_rpmconfigdir}/find-provides.ksyms
-%__kmp_requires		%{_rpmconfigdir}/find-requires.ksyms
-%__kmp_supplements	%{_rpmconfigdir}/find-supplements.ksyms
-%__kmp_path		^(/usr)?/lib/modules/.*\.ko(\.gz|\.xz|\.zst)?$
-%__kmp_path_exclude	^(/usr)?/lib/modules/[^/]*/kernel/.*\.ko(\.gz|\.xz|\.zst)$

--- a/scripts/find-requires.ksyms
+++ b/scripts/find-requires.ksyms
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-IFS=$'\n'
-
 case "$1" in
 kernel-module-*)    ;; # Fedora kernel module package names start with
                       # kernel-module.
-kernel*)           is_kernel_package=1 ;;
+kernel-*)           cat > /dev/null ; exit 0 ;;
 esac
+
+IFS=$'\n'
 
 modules=()
 modreqs=""

--- a/scripts/find-supplements.ksyms
+++ b/scripts/find-supplements.ksyms
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+case "$1" in
+kernel-module-*)    ;; # Fedora kernel module package names start with
+                      # kernel-module.
+kernel-*-extra)     ;; # Generate supplements for kernel-default-extra and -optional
+kernel-*-optional)  ;;
+kernel-*)           cat > /dev/null ; exit 0 ;;
+esac
+
 IFS=$'\n'
 
 print_modaliases() {


### PR DESCRIPTION
(bsc#1246561).

Note this excludes any random subdirectory called kernel, not only the ones that are provided by a kernel package.

Fixes: 8655017 ("kmp.attr: Run scripts for all modules (bsc#1237308).")