### PR TITLE
%requires_eq|ge(): Also takes into account provided packages

### DIFF
--- a/suse/macros
+++ b/suse/macros
@@ -281,8 +281,8 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 %py_sitedir             %{py_libdir}/site-packages
 
 # dropped from rpm package
-%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo "$t")}
-%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo "$t")}
+%requires_eq() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --whatprovides --qf 'Requires: %%{name} = %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_eq %*} does not resolve}"; echo "$t")}
+%requires_ge() %{expand:%(t=$(echo '%*' | LC_ALL=C xargs -r rpm -q --whatprovides --qf 'Requires: %%{name} >= %%{epoch}:%%{version}\\n' | sed -e 's/ (none):/ /' -e 's/ 0:/ /' | grep -v "is not"); test -n "$t" || echo "%%{error: %%%%{requires_ge %*} does not resolve}"; echo "$t")}
 %__perl			/usr/bin/perl
 
 # we use the macro as one can easily override it and thus disable LTO for a particular package


### PR DESCRIPTION
The %requires_eq|ge macros return an error if a package is requested that was added with “Provides:” and does not exist as a real package. This is corrected with this patch.

See https://bugzilla.opensuse.org/show_bug.cgi?id=1233409