### PR TITLE
Define %jobs as variable again (boo#1237231)

### DIFF
--- a/suse/macros
+++ b/suse/macros
@@ -302,6 +302,11 @@ Provides translations for the \"%{-n:%{-n*}}%{!-n:%{name}}\" package.
 # SUSE expects bash for building
 %_buildshell           /usr/bin/bash
 
+# Tell obs-build to not use a constant in %jobs for reproducible builds
+# boo#1237231 https://github.com/rpm-software-management/rpm/issues/2343
+# note: $RPM_BUILD_NCPUS is only available in rpm versions after 2022-11-09
+%jobs ${RPM_BUILD_NCPUS}
+
 # Expands to shell code to seot the compiler/linker environment
 # variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have
 # not been set already.


### PR DESCRIPTION
Define `%jobs` as variable again for reproducible builds.
Without this patch, obs-build would set %jobs to a constant that depends on the number of cores assigned to a build worker VM, making it hard to verify build results.

(cherry picked from commit 19b6c6f09bebc78edfca6716c0e6e155882bcd06)

This had been previously reverted in commit 3ee0a54200c412220379ce66a448b2187859d087 because of trouble with llvm that is now resolved.

References: https://bugzilla.opensuse.org/show_bug.cgi?id=1237231